### PR TITLE
Added workspaceFolders search

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import { getConfiguration, tryCatch } from './utils'
 export function activate(context: vscode.ExtensionContext) {
 
 	const vscexpress = new VSCExpress(context, 'view');
-	const workspacePath = vscode.workspace.rootPath;
+	const workspacePath = vscode.workspace.workspaceFolders;
 	if (workspacePath === undefined) {
 		showErrorMessage("Workdirectory is empty!");
 		throw "Workdirectory is empty!";

--- a/src/packageManagerService.ts
+++ b/src/packageManagerService.ts
@@ -45,7 +45,12 @@ export class packageManagerService {
             let files = glob.sync(`${folder.uri.fsPath}/**/*.+(csproj|fsproj)`, {
                 ignore: ['**/node_modules/**', '**/.git/**']
             });
-            result = result.concat(files);                
+
+            files.forEach(file => {
+                if (result.indexOf(file) === -1){
+                    result.push(file);  
+                }                  
+            });            
         });
 
         return result;


### PR DESCRIPTION
When open in a workspace the extension search on first workspace folder using the _deprecated_ `vscode.workspace.rootPath`.
I have changed `rootPath` with the _array string_ of **all** workspace folders.

Now the extension correctly read ALL workspace folders.

To test the actual behavior create a folder with this structure.

```
├── **my.code-workspace**
├── **mySolution.sln**
├── README.md
├── Docker
│   ├── Dockerfile
├── src
│   ├── Domain
│   │   ├── **Domain.csproj**
│   │   ├── bin
│   │   └── obj
│   ├── Infrastructure
│   │   ├── **Infrastructure.csproj**
│   │   ├── bin
│   │   └── obj
│   ├── NetCoreWeb
│   │   ├── **Web.csproj**
│   │   ├── Api
│   │   ├── Program.cs
│   │   ├── Startup.cs
│   │   ├── appsettings.json
│   │   ├── bin
│   │   ├── wwwroot
│   └── VueAPP
│       ├── node_modules
│       ├── package.json
│       ├── src
│       ├── tests
│       ├── tsconfig.json
│       ├── vue.config.js
│       └── yarn.lock
└── tests
    └── MyTests
        ├── **Test1.csproj**
        ├── Consts.cs
        ├── bin
        └── obj
```

Where the workspace is

```
{
	"folders": [
		{
			"path": "src\\VueAPP",
			"name": "🧃 VueJS"
		},
		{
			"path": "src\\Domain",
			"name": "🧱 Domain"
		},
		{
			"path": "src\\Infrastructure",
			"name": "🌉 Infrastructure"
		},
		{
			"path": "src\\NetCoreWeb",
			"name": "🕸️ Web"
		},
		{
			"path": "tests\\MyTests",
			"name": "🧪 Tests"
		},
		{
			"path": ".",
			"name": "🌵 Root"
		}
	]
}
```

Notice the last workspace node **Root** witch include ALL